### PR TITLE
Improve API key handling and ignore artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Environment variables
+.env
+
+# Data and result files
+FA-KES-Dataset.csv
+analyzed_articles_*.csv
+accuracy_evaluation_*.csv
+analysis_results.csv
+
+# Misc
+.DS_Store

--- a/accuracy_evaluation.py
+++ b/accuracy_evaluation.py
@@ -10,6 +10,7 @@ import csv
 import json
 from datetime import datetime
 from misinformation_detector import MisinformationDetector
+from utils import get_api_key
 
 
 def analyze_and_compare(input_file="FA-KES-Dataset.csv", num_articles=50, output_file=None):
@@ -22,15 +23,7 @@ def analyze_and_compare(input_file="FA-KES-Dataset.csv", num_articles=50, output
         output_file (str): Path to save detailed results (optional)
     """
     # Get API key
-    api_key = os.getenv('PERPLEXITY_API_KEY')
-    if not api_key:
-        print("Perplexity API key not found in environment variables.")
-        print("Please enter your Perplexity API key:")
-        api_key = input().strip()
-        
-        if not api_key:
-            print("Error: API key is required to proceed.")
-            sys.exit(1)
+    api_key = get_api_key()
     
     # Initialize the detector
     print("Initializing Misinformation Detector...")

--- a/debug_api.py
+++ b/debug_api.py
@@ -3,15 +3,15 @@
 Debug script to test Perplexity API connection
 """
 
-import os
 import requests
 import json
+from utils import get_api_key
 
 def test_api_connection():
     """Test the Perplexity API with a simple request"""
-    
+
     # Get API key
-    api_key = os.getenv('PERPLEXITY_API_KEY', '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')
+    api_key = get_api_key()
     
     url = "https://api.perplexity.ai/chat/completions"
     headers = {

--- a/example_usage.py
+++ b/example_usage.py
@@ -3,7 +3,7 @@
 Example usage of the MisinformationDetector class
 """
 
-import os
+from utils import get_api_key
 from misinformation_detector import MisinformationDetector
 
 
@@ -11,13 +11,8 @@ def main():
     """
     Example demonstrating how to use the MisinformationDetector
     """
-    # Get API key from environment variable
-    api_key = os.getenv('PERPLEXITY_API_KEY')
-    
-    if not api_key:
-        print("Please set the PERPLEXITY_API_KEY environment variable")
-        print("Example: export PERPLEXITY_API_KEY='your_api_key_here'")
-        return
+    # Get API key
+    api_key = get_api_key()
     
     # Initialize the detector
     detector = MisinformationDetector(api_key)

--- a/misinformation_detector.py
+++ b/misinformation_detector.py
@@ -14,6 +14,7 @@ import random
 from typing import Dict, List, Optional, Any
 from dataclasses import dataclass
 import time
+from utils import get_api_key
 
 
 @dataclass
@@ -381,15 +382,8 @@ def main():
     """
     Main function to run the misinformation detector
     """
-    # Get API key from environment variable or user input
-    api_key = os.getenv('PERPLEXITY_API_KEY')
-    
-    if not api_key:
-        api_key = input("Please enter your Perplexity AI API key: ").strip()
-        
-        if not api_key:
-            print("Error: API key is required")
-            sys.exit(1)
+    # Get API key
+    api_key = get_api_key()
     
     # Initialize the detector
     detector = MisinformationDetector(api_key)

--- a/run_articles_through_perplexity.py
+++ b/run_articles_through_perplexity.py
@@ -10,27 +10,7 @@ import csv
 import json
 from datetime import datetime
 from misinformation_detector import MisinformationDetector
-
-
-def get_api_key():
-    """
-    Get the Perplexity API key from environment variable or user input
-    
-    Returns:
-        str: The API key
-    """
-    api_key = os.getenv('PERPLEXITY_API_KEY')
-    
-    if not api_key:
-        print("Perplexity API key not found in environment variables.")
-        print("Please enter your Perplexity API key:")
-        api_key = input().strip()
-        
-        if not api_key:
-            print("Error: API key is required to proceed.")
-            sys.exit(1)
-    
-    return api_key
+from utils import get_api_key
 
 
 def analyze_articles(input_file="FA-KES-Dataset.csv", output_file=None, max_articles=None):

--- a/test_single_article.py
+++ b/test_single_article.py
@@ -3,9 +3,9 @@
 Quick test script to analyze a single article from the dataset
 """
 
-import os
 import csv
 from misinformation_detector import MisinformationDetector
+from utils import get_api_key
 
 
 def test_single_article():
@@ -13,16 +13,7 @@ def test_single_article():
     Test the analysis with a single article from the CSV dataset
     """
     # Get API key
-    api_key = os.getenv('PERPLEXITY_API_KEY')
-    
-    if not api_key:
-        print("Perplexity API key not found in environment variables.")
-        print("Please enter your Perplexity API key:")
-        api_key = input().strip()
-        
-        if not api_key:
-            print("Error: API key is required to proceed.")
-            return
+    api_key = get_api_key()
     
     # Initialize detector
     print("Initializing Misinformation Detector...")

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+
+def get_api_key() -> str:
+    """Retrieve the Perplexity API key from environment or prompt the user."""
+    api_key = os.getenv("PERPLEXITY_API_KEY")
+    if not api_key:
+        print("Perplexity API key not found in environment variables.")
+        api_key = input("Please enter your Perplexity API key: ").strip()
+        if not api_key:
+            print("Error: API key is required to proceed.")
+            sys.exit(1)
+    return api_key


### PR DESCRIPTION
## Summary
- centralize API key retrieval in new `utils.py`
- remove hard‑coded API key from debug script
- update scripts to use `get_api_key`
- add `.gitignore` for datasets and generated CSV files

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_683bd5f31f708326b23ef403cdf26d00